### PR TITLE
Button Mappings + Module Positions

### DIFF
--- a/rio/srcrobot/constants.py
+++ b/rio/srcrobot/constants.py
@@ -27,22 +27,21 @@ class Constants:
 
         # Drivetrain Constants
         trackWidth = Units.inchesToMeters(26.0)
-        wheelBase = Units.inchesToMeters(26.0)
+        wheelBase = Units.inchesToMeters(31.125)
         wheelCircumference = chosenModule.wheelCircumference
 
-        frontLeftLocation = Translation2d(Units.inchesToMeters(-10.375), Units.inchesToMeters(7.8125))
-        frontRightLocation = Translation2d(Units.inchesToMeters(10.375), Units.inchesToMeters(7.8125))
-        backLeftLocation = Translation2d(Units.inchesToMeters(-10.375), Units.inchesToMeters(-12.9375))
-        backRightLocation = Translation2d(Units.inchesToMeters(10.375), Units.inchesToMeters(-12.9375))
+        frontLeftLocation = Translation2d((wheelBase / 2.0) - trackWidth, -trackWidth / 2.0)
+        frontRightLocation = Translation2d((wheelBase / 2.0) - trackWidth, trackWidth / 2.0)
+        backLeftLocation = Translation2d(wheelBase / 2.0, -trackWidth / 2.0)
+        backRightLocation = Translation2d(wheelBase / 2.0, trackWidth / 2.0)
 
         robotCenterLocation = Translation2d(0.0, 0.0)
 
-        # Swerve Kinematics 
         swerveKinematics = SwerveDrive4Kinematics(
-            frontRightLocation,
-            backRightLocation,
             frontLeftLocation,
-            backLeftLocation
+            frontRightLocation,
+            backLeftLocation,
+            backRightLocation
         )
 
         # Module Gear Ratios
@@ -167,7 +166,8 @@ class Constants:
     
     class IndexerConstants:
         kIndexerMotorID = 14
-        kIndexerSpeed = 10.0
+        kIndexerMaxSpeedMS = 10.0
+        kIndexerIntakeSpeedMS = 2.6
 
     # An enumeration of known shot locations and data critical to executing the
     # shot. TODO decide on shooter velocity units and tune angles.

--- a/rio/srcrobot/constants.py
+++ b/rio/srcrobot/constants.py
@@ -27,13 +27,20 @@ class Constants:
 
         # Drivetrain Constants
         trackWidth = Units.inchesToMeters(26.0)
-        wheelBase = Units.inchesToMeters(31.125)
+        # wheelBase = Units.inchesToMeters(31.125)
+        wheelBase = Units.inchesToMeters(26.0)
         wheelCircumference = chosenModule.wheelCircumference
 
-        frontLeftLocation = Translation2d((wheelBase / 2.0) - trackWidth, -trackWidth / 2.0)
-        frontRightLocation = Translation2d((wheelBase / 2.0) - trackWidth, trackWidth / 2.0)
+        # frontLeftLocation = Translation2d((wheelBase / 2.0) - trackWidth, -trackWidth / 2.0)
+        # frontRightLocation = Translation2d((wheelBase / 2.0) - trackWidth, trackWidth / 2.0)
+        # backLeftLocation = Translation2d(wheelBase / 2.0, -trackWidth / 2.0)
+        # backRightLocation = Translation2d(wheelBase / 2.0, trackWidth / 2.0)
+
+        frontLeftLocation = Translation2d(-wheelBase / 2.0, -trackWidth / 2.0)
+        frontRightLocation = Translation2d(-wheelBase / 2.0, trackWidth / 2.0)
         backLeftLocation = Translation2d(wheelBase / 2.0, -trackWidth / 2.0)
         backRightLocation = Translation2d(wheelBase / 2.0, trackWidth / 2.0)
+
 
         robotCenterLocation = Translation2d(0.0, 0.0)
 

--- a/rio/srcrobot/robot_container.py
+++ b/rio/srcrobot/robot_container.py
@@ -1,7 +1,7 @@
 from wpilib.interfaces import GenericHID
 from wpilib import Joystick
 from wpilib import XboxController
-from commands2.button import CommandXboxController
+from commands2.button import CommandXboxController, Trigger
 from commands2 import Command, Subsystem
 from commands2 import InstantCommand, ConditionalCommand, WaitCommand
 from commands2.button import JoystickButton
@@ -167,13 +167,7 @@ class RobotContainer:
 
         #Shooter Buttons
         self.shooterRev.onTrue(self.s_Shooter.shoot())
-        self.shoot.onTrue(
-            ConditionalCommand(
-                self.s_Indexer.indexerShoot(),
-                self.s_Indexer.stopIndexer(),
-                self.s_Shooter.isShooterReady
-            )
-        )
+        self.shoot.and_(self.s_Shooter.isShooterReady).onTrue(self.s_Indexer.indexerShoot())
 
 
 

--- a/rio/srcrobot/robot_container.py
+++ b/rio/srcrobot/robot_container.py
@@ -40,7 +40,7 @@ class RobotContainer:
 
     sysId = JoystickButton(driver, XboxController.Button.kY)
 
-    robotCentric_value = True
+    robotCentric_value = False
 
     # Subsystems
     s_Swerve : Swerve = Swerve()
@@ -74,22 +74,20 @@ class RobotContainer:
         self.faceRight = self.driver.b()
         self.faceLeft = self.driver.x()
         self.shoot = self.driver.rightTrigger() #just for testing will be removed later
-        self.resetToAbsoluteButton = self.driver.rightBumper()
-        self.intakeOn = self.driver.povRight()
-        self.intakeOff = self.driver.povLeft()
+        self.intake = self.driver.rightBumper()
+        self.intakeReverse = self.driver.leftBumper()
         # Operator Controls
         self.manualArm = self.operator.leftBumper() 
-        self.armHome = self.operator.rightTrigger()
-        self.shooterOff = self.operator.rightBumper()
-        self.reverse = self.operator.leftTrigger()
-        self.queSubFront = self.operator.a()
-        self.quePodium = self.operator.y()
-        self.queSubRight = self.operator.b()
-        self.queSubLeft = self.operator.x()
-        self.queAmp = self.operator.povUp()
-        self.queClimbFront = self.operator.povDown()
-        self.queClimbRight = self.operator.povRight()
-        self.queClimbLeft = self.operator.povLeft()
+        self.armHome = self.operator.rightBumper()
+        self.shooterRev = self.operator.rightTrigger()
+        # self.queSubFront = self.operator.a()
+        # self.quePodium = self.operator.y()
+        # self.queSubRight = self.operator.b()
+        # self.queSubLeft = self.operator.x()
+        # self.queAmp = self.operator.povUp()
+        # self.queClimbFront = self.operator.povDown()
+        # self.queClimbRight = self.operator.povRight()
+        # self.queClimbLeft = self.operator.povLeft()
         self.configureButtonBindings()
 
         self.auton_selector = SendableChooser()
@@ -148,9 +146,10 @@ class RobotContainer:
         # Arm Buttons
         self.s_Arm.setDefaultCommand(self.s_Arm.seekArmZero())
         self.manualArm.whileTrue(self.s_Arm.moveArm(lambda: self.operator.getLeftY()))
-        self.queAmp.onTrue(self.s_Arm.servoArmToTarget(Constants.ShooterConstants.kAmpPivotAngle))
-        self.quePodium.onTrue(self.s_Arm.servoArmToTarget(Constants.ShooterConstants.kPodiumPivotAngle))
-        self.queSubFront.onTrue(self.s_Arm.servoArmToTarget(Constants.ShooterConstants.kSubwooferPivotAngle))
+        # self.queAmp.onTrue(self.s_Arm.servoArmToTarget(Constants.ShooterConstants.kAmpPivotAngle))
+        # self.quePodium.onTrue(self.s_Arm.servoArmToTarget(Constants.ShooterConstants.kPodiumPivotAngle))
+        # self.queSubFront.onTrue(self.s_Arm.servoArmToTarget(Constants.ShooterConstants.kSubwooferPivotAngle))
+
         # Driver Buttons
         self.zeroGyro.onTrue(InstantCommand(lambda: self.s_Swerve.zeroYaw()))
         self.robotCentric.onFalse(InstantCommand(lambda: self.toggleFieldOriented()))
@@ -159,16 +158,22 @@ class RobotContainer:
         self.faceBack.onTrue(TurnInPlace(self.s_Swerve, lambda: (Rotation2d.fromDegrees(0)), translation, strafe, rotation, robotcentric))
         self.faceLeft.onTrue(TurnInPlace(self.s_Swerve, lambda: (Rotation2d.fromDegrees(90)), translation, strafe, rotation, robotcentric))
         self.faceRight.onTrue(TurnInPlace(self.s_Swerve, lambda: (Rotation2d.fromDegrees(-90)), translation, strafe, rotation, robotcentric))
-        
 
         #Intake Buttons
-        self.intakeOn.onTrue(self.s_Intake.setIntakeSpeed(Constants.IntakeConstants.kIntakeSpeed).alongWith(self.s_Indexer.indexerIntake()))
-        self.intakeOff.onTrue(self.s_Intake.stopIntake().alongWith(self.s_Indexer.stopIndexer()))
+        self.s_Intake.setDefaultCommand(self.s_Intake.stopIntake())
+        self.s_Indexer.setDefaultCommand(self.s_Indexer.stopIndexer())
+        self.intake.whileTrue(self.s_Intake.intake().alongWith(self.s_Indexer.indexerIntake()))
+        self.intakeReverse.whileTrue(self.s_Intake.outtake().alongWith(self.s_Indexer.indexerOuttake()))
 
         #Shooter Buttons
-        self.shooterOff.onTrue(self.s_Shooter.stop().alongWith(self.s_Indexer.stopIndexer()))
-        self.shoot.onTrue(self.s_Shooter.shoot().andThen(WaitCommand(2.0)).andThen(self.s_Indexer.indexerShoot()))
-        self.reverse.onTrue(self.s_Shooter.shootReverse().alongWith(self.s_Indexer.indexerIntake()))
+        self.shooterRev.onTrue(self.s_Shooter.shoot())
+        self.shoot.onTrue(
+            ConditionalCommand(
+                self.s_Indexer.indexerShoot(),
+                self.s_Indexer.stopIndexer(),
+                self.s_Shooter.isShooterReady
+            )
+        )
 
 
 

--- a/rio/srcrobot/robot_container.py
+++ b/rio/srcrobot/robot_container.py
@@ -166,8 +166,9 @@ class RobotContainer:
         self.intakeReverse.whileTrue(self.s_Intake.outtake().alongWith(self.s_Indexer.indexerOuttake()))
 
         #Shooter Buttons
-        self.shooterRev.onTrue(self.s_Shooter.shoot())
-        self.shoot.and_(self.s_Shooter.isShooterReady).onTrue(self.s_Indexer.indexerShoot())
+        self.s_Shooter.setDefaultCommand(self.s_Shooter.idle())
+        self.shooterRev.whileTrue(self.s_Shooter.shoot())
+        self.shoot.and_(self.s_Shooter.isShooterReady).whileTrue(self.s_Indexer.indexerShoot())
 
 
 

--- a/rio/srcrobot/subsystems/Shooter.py
+++ b/rio/srcrobot/subsystems/Shooter.py
@@ -64,8 +64,8 @@ class Shooter(Subsystem):
         return self.run(lambda: self.setShooterVelocity(-Constants.ShooterConstants.kPodiumShootSpeed))
     
     def isShooterReady(self):
-        topShooterReady = abs(abs(self.topShooterVelocitySupplier()) - self.currentShotVelocity) < 0.5
-        bottomShooterReady = abs(abs(self.bottomShooterVelocitySupplier()) - self.currentShotVelocity) < 0.5
+        topShooterReady = abs(self.topShooterVelocitySupplier() - self.currentShotVelocity) < 0.5
+        bottomShooterReady = abs(self.bottomShooterVelocitySupplier() - self.currentShotVelocity) < 0.5
 
         return topShooterReady and bottomShooterReady
 

--- a/rio/srcrobot/subsystems/Shooter.py
+++ b/rio/srcrobot/subsystems/Shooter.py
@@ -38,21 +38,33 @@ class Shooter(Subsystem):
         self.VelocityControl = VelocityVoltage(0)
         self.VoltageControl = VoltageOut(0)
         self.percentOutput = DutyCycleOut(0)
-        
+
+        self.currentShotVelocity = 0.0
+
+    def setShooterVelocity(self, velocity):
+        self.topShooter.set_control(self.VelocityControl.with_velocity(Conversions.MPSToRPS(velocity,  0.101 * math.pi)))
+        self.bottomShooter.set_control(self.VelocityControl.with_velocity(Conversions.MPSToRPS(velocity,  0.101 * math.pi)))
+
+        self.currentShotVelocity = Conversions.MPSToRPS(velocity,  0.101 * math.pi)
+
+    def neutralizeShooter(self):
+        self.topShooter.set_control(self.VoltageControl.with_output(0))
+        self.bottomShooter.set_control(self.VoltageControl.with_output(0))
+
+    def idle(self):
+        return self.run(self.setShooterVelocity(Constants.ShooterConstants.kAmpShootSpeed))    
+    
     def shoot(self):
-        # return InstantCommand(lambda: self.bottomShooter.set_control(self.VelocityControl.with_velocity(Conversions.MPSToRPS(Constants.ShooterConstants.kPodiumShootSpeed,  0.101 * math.pi)))).alongWith(
-        #     InstantCommand(lambda:self.topShooter.set_control(self.VelocityControl.with_velocity(Conversions.MPSToRPS(Constants.ShooterConstants.kPodiumShootSpeed,  0.101 * math.pi))))
-        # )
-        return InstantCommand(lambda: self.bottomShooter.set_control(self.VelocityControl.with_velocity(Conversions.MPSToRPS(Constants.ShooterConstants.kPodiumShootSpeed,  0.101 * math.pi)))).alongWith(
-            InstantCommand(lambda:self.topShooter.set_control(self.VelocityControl.with_velocity(Conversions.MPSToRPS(Constants.ShooterConstants.kPodiumShootSpeed,  0.101 * math.pi))))
-        )
+        return self.run(lambda: self.setShooterVelocity(Constants.ShooterConstants.kPodiumShootSpeed))
 
     def shootReverse(self):
-        return InstantCommand(lambda: self.bottomShooter.set_control(self.VelocityControl.with_velocity(Conversions.MPSToRPS(-Constants.ShooterConstants.kPodiumShootSpeed,  0.101 * math.pi)))).alongWith(
-            InstantCommand(lambda:self.topShooter.set_control(self.VelocityControl.with_velocity(Conversions.MPSToRPS(-Constants.ShooterConstants.kPodiumShootSpeed,  0.101 * math.pi))))
-        )
+        return self.run(lambda: self.setShooterVelocity(-Constants.ShooterConstants.kPodiumShootSpeed))
+    
+    def isShooterReady(self):
+        topShooterReady = abs(abs(self.topShooter.get_velocity().as_supplier()) - self.currentShotVelocity) < 0.5
+        bottomShooterReady = abs(abs(self.topShooter.get_velocity().as_supplier()) - self.currentShotVelocity) < 0.5
+
+        return topShooterReady and bottomShooterReady
 
     def stop(self):
-        return InstantCommand(lambda: self.bottomShooter.set_control(self.VoltageControl.with_output(0))).alongWith(
-            InstantCommand(lambda:self.topShooter.set_control(self.VoltageControl.with_output(0)))
-        )
+        return self.run(lambda: self.neutralizeShooter())

--- a/rio/srcrobot/subsystems/Shooter.py
+++ b/rio/srcrobot/subsystems/Shooter.py
@@ -41,6 +41,9 @@ class Shooter(Subsystem):
 
         self.currentShotVelocity = 0.0
 
+        self.topShooterVelocitySupplier = self.topShooter.get_velocity().as_supplier()
+        self.bottomShooterVelocitySupplier = self.bottomShooter.get_velocity().as_supplier()
+
     def setShooterVelocity(self, velocity):
         self.topShooter.set_control(self.VelocityControl.with_velocity(Conversions.MPSToRPS(velocity,  0.101 * math.pi)))
         self.bottomShooter.set_control(self.VelocityControl.with_velocity(Conversions.MPSToRPS(velocity,  0.101 * math.pi)))
@@ -61,8 +64,8 @@ class Shooter(Subsystem):
         return self.run(lambda: self.setShooterVelocity(-Constants.ShooterConstants.kPodiumShootSpeed))
     
     def isShooterReady(self):
-        topShooterReady = abs(abs(self.topShooter.get_velocity().as_supplier()) - self.currentShotVelocity) < 0.5
-        bottomShooterReady = abs(abs(self.topShooter.get_velocity().as_supplier()) - self.currentShotVelocity) < 0.5
+        topShooterReady = abs(abs(self.topShooterVelocitySupplier()) - self.currentShotVelocity) < 0.5
+        bottomShooterReady = abs(abs(self.bottomShooterVelocitySupplier()) - self.currentShotVelocity) < 0.5
 
         return topShooterReady and bottomShooterReady
 

--- a/rio/srcrobot/subsystems/indexer.py
+++ b/rio/srcrobot/subsystems/indexer.py
@@ -12,11 +12,19 @@ class Indexer(Subsystem):
         self.indexerMotor.setInverted(True)
         self.indexerMotor.config_kP(0, 2.0)
 
+        self.indexerDiameter = 0.031
+        self.indexerEncoderCPR = 2048.0
+        self.indexerIntakeVelocity = -(Constants.IndexerConstants.kIndexerIntakeSpeedMS/(math.pi*self.indexerDiameter))*self.indexerEncoderCPR
+        self.indexerShootVelocity = -(Constants.IndexerConstants.kIndexerMaxSpeedMS/(math.pi*self.indexerDiameter))*self.indexerEncoderCPR
+
     def indexerIntake(self):
-        return InstantCommand(lambda: self.indexerMotor.set(TalonSRXControlMode.Velocity, -(Constants.IndexerConstants.kIndexerSpeed/(math.pi*0.031))*2048.0))
+        return self.run(lambda: self.indexerMotor.set(TalonSRXControlMode.Velocity, self.indexerIntakeVelocity))
 
     def indexerShoot(self):
-        return InstantCommand(lambda: self.indexerMotor.set(TalonSRXControlMode.Velocity, -(Constants.IndexerConstants.kIndexerSpeed/(math.pi*0.031))*2048.0))
+        return self.run(lambda: self.indexerMotor.set(TalonSRXControlMode.Velocity, self.indexerShootVelocity))
+    
+    def indexerOuttake(self):
+        return self.run(lambda: self.indexerMotor.set(TalonSRXControlMode.Velocity, -self.indexerIntakeVelocity))
 
     def stopIndexer(self):
-        return InstantCommand(lambda: self.indexerMotor.set(TalonSRXControlMode.PercentOutput, 0.0))
+        return self.run(lambda: self.indexerMotor.set(TalonSRXControlMode.PercentOutput, 0.0))

--- a/rio/srcrobot/subsystems/intake.py
+++ b/rio/srcrobot/subsystems/intake.py
@@ -10,8 +10,11 @@ class Intake(Subsystem):
         self.intakeMotor = TalonSRX(Constants.IntakeConstants.kIntakeMotorID)
         self.intakeMotor.configFactoryDefault()
 
-    def setIntakeSpeed(self, speed: float):
-        return InstantCommand(lambda: self.intakeMotor.set(TalonSRXControlMode.PercentOutput, 1.0))
+    def intake(self):
+        return self.run(lambda: self.intakeMotor.set(TalonSRXControlMode.PercentOutput, 1.0))
+    
+    def outtake(self):
+        return self.run(lambda: self.intakeMotor.set(TalonSRXControlMode.PercentOutput, -1.0))
 
     def stopIntake(self):
-        return InstantCommand(lambda: self.intakeMotor.set(TalonSRXControlMode.Current, 0.0))
+        return self.run(lambda: self.intakeMotor.set(TalonSRXControlMode.Current, 0.0))


### PR DESCRIPTION
### Button Mapping
Changed the button mapping to be more testing friendly (for Saturday), especially when the queue system has not been fully implemented yet. This should change to reflect Raza's desired button mapping once the needed features are implemented. This is the new button mapping:

- Driver Controls:
   - **zeroYaw**: back
   - **fieldOriented**: start
   - Turning Commands
      - **Forward**: Y
      - **Back**: A
      - **Right**: B
      - **Left**: X
   - **shoot**: rightTrigger
     - This button will run the indexer to shoot the note only when the shooter flywheel is at the appropriate speed
   - **intake**: rightBumper
   - **outtake**: leftBumper
- Operator Controls:
   - **manualArm**: leftY while holding leftBumper
   - **armHome**: rightBumper
   - **shooterRev**: rightTrigger
     - This button will set the shooter velocity ("rev" the shooter)
 
Along with this change were some QoL changes to make shooter/indexer/intake development easier and more readable
     
### Module Positions
After examining the module positions that were working with the test robot, I found that all module positions had to be rotated 180 degrees clockwise from the correct position in order for movement to be correct (essentially the x and y axes are flipped):

Ex: frontLeft is in the position of backRight, frontRight is in the position of backLeft, etc
  
Accounting for this, I updated the module positions based on wheelBase and trackWidth as below:

wheelBase = 31.125 inches
trackWidth = 26 inches

FL = ((wheelBase / 2.0) - trackWidth, -trackWidth / 2.0)
FR = ((wheelBase / 2.0) - trackWidth, trackWidth / 2.0)
BL = (wheelBase / 2.0, -trackWidth / 2.0)
BR = (wheelBase / 2.0, trackWidth / 2.0)

Here is a picture of how I came up with this:

![IMG_0845](https://github.com/RoboEagles4828/rift2024/assets/59266397/1f8d887a-246d-4aa9-aabb-c9a6b02b36ab)