### PR TITLE
isreadyChgs

### DIFF
--- a/rio/srcrobot/robot.py
+++ b/rio/srcrobot/robot.py
@@ -2,6 +2,8 @@ from wpilib import TimedRobot
 from commands2 import Command
 from commands2 import CommandScheduler
 from CTREConfigs import CTREConfigs
+from rio.srcrobot.constants import Constants
+from rio.srcrobot.gameState import GameState
 from robot_container import RobotContainer
 import wpilib
 
@@ -43,6 +45,7 @@ class Robot(TimedRobot):
     # teleop starts running. If you want the autonomous to
     # continue until interrupted by another command, remove
     # this line or comment it out.
+    GameState().setNextShot(Constants.NextShot.SPEAKER_CENTER)
     self.m_robotContainer.s_Shooter.setDefaultCommand(self.m_robotContainer.s_Shooter.stop())
 
     if self.m_autonomousCommand is not None:

--- a/rio/srcrobot/robotState.py
+++ b/rio/srcrobot/robotState.py
@@ -42,33 +42,28 @@ class RobotState:
         self.m_armAngleSupplier = armAngleSupplier
         self.m_shooterVelocitySupplier = shooterVelocitySupplier
 
-    def isShooterReady(self, shot=None) -> bool:
+    def isShooterReady(self) -> bool:
         """
         Return true if the current arm angle and shooter velocity are both within
         tolerance for the needs of the next desired shot.
         """
-        if shot is None:
-            shot = self.m_gameState.getNextShot()
+        shot = self.m_gameState.getNextShot()
         return math.isclose(
             shot.m_shooterVelocity,
             self.m_shooterVelocitySupplier(),
             abs_tol=self.kShooterVelocityTolerance,
         )
     
-    def isArmReady(self, shot=None) -> bool:
-        if shot is None:
-            shot = self.m_gameState.getNextShot()
+    def isArmReady(self) -> bool:
+        shot = self.m_gameState.getNextShot()
         return math.isclose(
             shot.m_armAngle,
             self.m_armAngleSupplier(),
             abs_tol=self.kArmAngleTolerance
         )
     
-    def isArmAndShooterReady(self, shot=None) -> bool:
-        next = shot
-        if next is None:
-            next = self.m_gameState.getNextShot()
-        return self.isShooterReady(shot=next) and self.isArmReady(shot=next)
+    def isArmAndShooterReady(self) -> bool:
+        return self.isShooterReady() and self.isArmReady()
 
     def isRobotReady(self) -> bool:
         """

--- a/rio/srcrobot/robot_container.py
+++ b/rio/srcrobot/robot_container.py
@@ -174,9 +174,9 @@ class RobotContainer:
         Shuffleboard.getTab("Teleoperated").addBoolean("Zero Gyro", self.zeroGyro.getAsBoolean)
         Shuffleboard.getTab("Teleoperated").addBoolean("Beam Break", self.s_Indexer.getBeamBreakState)
         Shuffleboard.getTab("Teleoperated").addDouble("Shooter Speed", self.s_Shooter.getVelocity)
-        Shuffleboard.getTab("Teleoperated").addBoolean("Shooter Ready", lambda: self.m_robotState.isShooterReady(Constants.NextShot.CENTER_AUTO))
-        Shuffleboard.getTab("Teleoperated").addBoolean("Arm Ready", lambda: self.m_robotState.isArmReady(Constants.NextShot.CENTER_AUTO))
-        Shuffleboard.getTab("Teleoperated").addBoolean("Arm + Shooter Ready", lambda: self.m_robotState.isArmAndShooterReady(shot=Constants.NextShot.CENTER_AUTO))
+        Shuffleboard.getTab("Teleoperated").addBoolean("Shooter Ready", lambda: self.m_robotState.isShooterReady())
+        Shuffleboard.getTab("Teleoperated").addBoolean("Arm Ready", lambda: self.m_robotState.isArmReady())
+        Shuffleboard.getTab("Teleoperated").addBoolean("Arm + Shooter Ready", lambda: self.m_robotState.isArmAndShooterReady())
         Shuffleboard.getTab("Teleoperated").addDouble("Target Angle", lambda: self.m_robotState.m_gameState.getNextShotRobotAngle())
         Shuffleboard.getTab("Teleoperated").addDouble("Swerve Heading", lambda: self.s_Swerve.getHeading().degrees())
 
@@ -193,6 +193,7 @@ class RobotContainer:
         """
         Used during automode commands to shoot any Constants.NextShot.
         """
+        self.m_robotState.m_gameState.setNextShot(autoShot)
         armTimeoutSec = (autoShot.m_armAngle / 45.0) + 1.0
         return SequentialCommandGroup(
             InstantCommand(
@@ -204,7 +205,7 @@ class RobotContainer:
                 )
             ),
             WaitUntilCommand(
-                lambda: self.m_robotState.isArmAndShooterReady(shot=autoShot)
+                lambda: self.m_robotState.isArmAndShooterReady()
             ).withTimeout(1.0),
             self.s_Indexer.indexerShoot().withTimeout(3.0).withName("AutoShoot"),
             # InstantCommand(lambda: self.s_Shooter.brake, self.s_Shooter).withName("AutoShooterBrake"),


### PR DESCRIPTION
This change makes the dashboard indicators for is arm ready and is shooter ready work for all shots in auto and teleop, not just a particular shot. It also ensures we enter teleop with center speaker selected as it has always been. I strongly recommend this change for further arm and shooter optimization.