### PR TITLE
this should shoot when arm and shooter ready

### DIFF
--- a/rio/srcrobot/robot_container.py
+++ b/rio/srcrobot/robot_container.py
@@ -214,8 +214,8 @@ class RobotContainer:
                 )
                 .andThen(self.s_Indexer.indexerShoot()),
             ),
-            self.s_Arm.seekArmZero().withTimeout(1.0),
             self.s_Indexer.instantStop(),
+            self.s_Arm.seekArmZero().withTimeout(1.0),
         )
 
     """

--- a/rio/srcrobot/robot_container.py
+++ b/rio/srcrobot/robot_container.py
@@ -198,11 +198,13 @@ class RobotContainer:
         """
         Used during automode commands to shoot any Constants.NextShot.
         """
-        shotTimeoutSec = (autoShot.m_armAngle / 45.0) + 1.5
+        shotTimeoutSec = (autoShot.m_armAngle / 45.0) + 1.0
         return SequentialCommandGroup(
             InstantCommand(lambda: self.m_robotState.m_gameState.setNextShot(autoShot)),
             ParallelDeadlineGroup(
-                WaitUntilCommand(lambda: self.m_robotState.isArmAndShooterReady()),
+                WaitUntilCommand(lambda: self.m_robotState.isArmAndShooterReady())
+                .withTimeout(shotTimeoutSec)
+                .andThen(self.s_Indexer.indexerShoot()),
                 InstantCommand(
                     lambda: self.s_Shooter.setShooterVelocity(
                         autoShot.m_shooterVelocity
@@ -210,8 +212,7 @@ class RobotContainer:
                     self.s_Shooter,
                 ),
                 self.s_Arm.servoArmToTarget(autoShot.m_armAngle),
-            ).withTimeout(shotTimeoutSec),
-            self.s_Indexer.indexerShoot(),
+            ),
             self.s_Indexer.instantStop(),
             self.s_Arm.seekArmZero().withTimeout(1.0),
         )


### PR DESCRIPTION
I took a fresh look at the auto shot logic and the problem jumped right out at me. The current code in rio
 1) runs a parallel command group that revs the shooter and servos the arm.
 2) The servo of the arm will not stop until the timeout happens (the delay we always see). The servo command is designed to never end until interrupted so that it will hold the arm position (this is important).
 3) Note that at this point in the shoot sequence (that initial parallel group just ended, that no command will be running for the arm. The sequence requires it, so the default command will not kick in. Inertia is all the holds the arm now.
 4) After that, we test for ready, shoot and zero the arm.

In the proposal, assuming I have the syntax right, it will:
 1) Do these in parallel:
     a) rev the shooter,
     b) servo arm and keep running to hold arm,
     c) wait a small amount to make sure proper shot is set, and then test for ready with a timeout, and then shoot.
 2) Zero arm